### PR TITLE
Remove the need to publish resources

### DIFF
--- a/src/ApiToken.php
+++ b/src/ApiToken.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App;
+namespace UoGSoE\ApiTokenMiddleware;
 
 use Illuminate\Database\Eloquent\Model;
 

--- a/src/ApiTokenServiceProvider.php
+++ b/src/ApiTokenServiceProvider.php
@@ -8,13 +8,7 @@ class ApiTokenServiceProvider extends ServiceProvider
 {
     public function boot(\Illuminate\Routing\Router $router)
     {
-        $this->publishes([
-            __DIR__.'/ApiToken.php' => app_path('ApiToken.php'),
-        ]);
-        $this->publishes([
-            __DIR__.'/../migrations/2018_04_18_090739_create_api_tokens_table.php' =>
-                database_path('migrations/2018_04_18_090739_create_api_tokens_table.php'),
-        ]);
+        $this->loadMigrationsFrom(__DIR__.'/../migrations');
         $router->aliasMiddleware('apitoken', 'UoGSoE\ApiTokenMiddleware\BasicApiTokenMiddleware');
         if ($this->app->runningInConsole()) {
             $this->commands([

--- a/src/BasicApiTokenMiddleware.php
+++ b/src/BasicApiTokenMiddleware.php
@@ -3,7 +3,7 @@
 namespace UoGSoE\ApiTokenMiddleware;
 
 use Closure;
-use App\ApiToken;
+use UoGSoE\ApiTokenMiddleware\ApiToken;
 
 class BasicApiTokenMiddleware
 {

--- a/src/Commands/CreateToken.php
+++ b/src/Commands/CreateToken.php
@@ -3,7 +3,7 @@
 namespace UoGSoE\ApiTokenMiddleware\Commands;
 
 use Illuminate\Console\Command;
-use App\ApiToken;
+use UoGSoE\ApiTokenMiddleware\ApiToken;
 
 class CreateToken extends Command
 {

--- a/src/Commands/DeleteToken.php
+++ b/src/Commands/DeleteToken.php
@@ -3,7 +3,7 @@
 namespace UoGSoE\ApiTokenMiddleware\Commands;
 
 use Illuminate\Console\Command;
-use App\ApiToken;
+use UoGSoE\ApiTokenMiddleware\ApiToken;
 
 class DeleteToken extends Command
 {

--- a/src/Commands/ListTokens.php
+++ b/src/Commands/ListTokens.php
@@ -2,7 +2,7 @@
 
 namespace UoGSoE\ApiTokenMiddleware\Commands;
 
-use App\ApiToken;
+use UoGSoE\ApiTokenMiddleware\ApiToken;
 use Illuminate\Console\Command;
 
 class ListTokens extends Command

--- a/src/Commands/RegenerateToken.php
+++ b/src/Commands/RegenerateToken.php
@@ -3,7 +3,7 @@
 namespace UoGSoE\ApiTokenMiddleware\Commands;
 
 use Illuminate\Console\Command;
-use App\ApiToken;
+use UoGSoE\ApiTokenMiddleware\ApiToken;
 
 class RegenerateToken extends Command
 {


### PR DESCRIPTION
Small change to the package to remove the need to the ApiToken model and the migrations to be published. This makes the package more 'seamless' and codebases that use this package a bit cleaner.